### PR TITLE
fix(server_helper): process signal empty stream for platform windows

### DIFF
--- a/packages/arcade/lib/src/helpers/server_helpers.dart
+++ b/packages/arcade/lib/src/helpers/server_helpers.dart
@@ -22,7 +22,9 @@ void setupProcessSignalWatchers(
     await closeServerExit(server);
   });
 
-  ProcessSignal.sigterm.watch().listen((_) async {
-    await closeServerExit(server);
-  });
+  Platform.isWindows
+      ? const Stream.empty()
+      : ProcessSignal.sigterm.watch().listen((_) async {
+          await closeServerExit(server);
+        });
 }


### PR DESCRIPTION
fixed an issue related to running the program on a Windows machine

error: 
```Unhandled exception:
SignalException: Failed to listen for SIGTERM, osError: OS Error: The request is not supported.
, errno = 50```